### PR TITLE
Drop ENV setting

### DIFF
--- a/components/python/python-312/Makefile
+++ b/components/python/python-312/Makefile
@@ -89,13 +89,6 @@ CFLAGS += $(CPP_XPG6MODE)
 # are based on Solaris 11 minimum supported system requirements.
 XPROFILE_DIR= $(BUILD_DIR_$(BITS))/.profile
 
-# PYTHONPATH in the environment can be harmful, but setting it to empty via
-# _INSTALL_ENV causes problems too, so just ignore the entire environment.
-# (see 20396493) Because of this, we have to explicitly specify PATH in
-# multiple places below. Also up the limit of maximum opened files for
-# testing purposes and pgo.
-ENV := ulimit -n 16384; $(ENV) -i
-
 # Configure script should look into sbin folder when looking for dtrace
 CONFIGURE_ENV += PATH="$(PATH):/usr/sbin"
 


### PR DESCRIPTION
It is plain evil.  We already build in clean environment, so `$(ENV) -i` is not needed.  And the file limit is 64k by default, so we do not need the `ulimit` part either.

See also https://github.com/OpenIndiana/oi-userland/pull/12095#issuecomment-1549007803