### PR TITLE
Drop _LARGEFILE64_SOURCE; we compile 64-bit only

### DIFF
--- a/components/python/python-312/Makefile
+++ b/components/python/python-312/Makefile
@@ -68,8 +68,6 @@ CPPFLAGS += -IPython
 
 # to find the ncurses headers
 CPPFLAGS += -I/usr/include/ncurses
-# enable large files how they did in JDS
-CPPFLAGS += -D_LARGEFILE64_SOURCE
 
 # libffi for _ctypes
 CPPFLAGS += $(shell pkg-config --cflags-only-I libffi)


### PR DESCRIPTION
See also lfcompile64(7).