### PR TITLE
06-rbac.patch: fix SyntaxWarning

### DIFF
--- a/components/python/python-312/patches/06-rbac.patch
+++ b/components/python/python-312/patches/06-rbac.patch
@@ -1289,7 +1289,7 @@ some point, but the suitability (or lack thereof) has not yet been determined.
 +                sys.exit(0)
 +
 +    child = os.wait()
-+    if child[1] is not 0:
++    if child[1] != 0:
 +        print("setppriv. Bad exit status from pid %i\n" % child[0])
 +        return False
 +    return True


### PR DESCRIPTION
Fix for:
```
Python-3.12.2/Lib/test/privrbactest.py:45: SyntaxWarning: "is not" with 'int' literal. Did you mean "!="?
  if child[1] is not 0:
```