### PR TITLE
no test redirect

### DIFF
--- a/components/python/python-312/Makefile
+++ b/components/python/python-312/Makefile
@@ -151,8 +151,8 @@ TESTOPTS_PYTHON_TEST=
 # The "-v" ensures verbose mode.
 COMPONENT_TEST_ENV += EXTRATESTOPTS="-v -uall,-network $(TESTOPTS_PYTHON_TEST)"
 
-# Prevent the tests from getting stuck waiting for input.
-COMPONENT_TEST_TARGETS= test < /dev/null
+# Override default test target.  See README.rst.
+COMPONENT_TEST_TARGETS = test
 
 # The test output contains details from each test, in whatever order they
 # complete.  The default _TRANSFORMER is not powerful enough to deal with


### PR DESCRIPTION
I believe if such redirect is really needed to see tests passed then it is a bug that needs to be root caused and fixed.

Test results with current HEAD (use parallel build) + no test redirect:
```
== Tests result: FAILURE ==

19 tests skipped:
    test.test_asyncio.test_windows_events
    test.test_asyncio.test_windows_utils test.test_gdb.test_backtrace
    test.test_gdb.test_cfunction test.test_gdb.test_cfunction_full
    test.test_gdb.test_misc test.test_gdb.test_pretty_print test_epoll
    test_kqueue test_launcher test_msilib test_perf_profiler
    test_perfmaps test_readline test_startfile test_winconsoleio
    test_winreg test_winsound test_wmi

9 tests skipped (resource denied):
    test_smtpnet test_socketserver test_tix test_tkinter test_ttk
    test_urllib2net test_urllibnet test_xmlrpc_net test_zipfile64

3 tests failed:
    test_dtrace test_xml_etree test_xml_etree_c

457 tests OK.

Total duration: 14 min 38 sec
Total tests: run=41,760 failures=17 skipped=1,546
Total test files: run=479/488 failed=3 skipped=19 resource_denied=9
Result: FAILURE
```